### PR TITLE
Update allowed regions for Log Analytics to Azure Automation mapping

### DIFF
--- a/deployments/azure_log_analytics/azure_log_analytics.json
+++ b/deployments/azure_log_analytics/azure_log_analytics.json
@@ -193,7 +193,7 @@
             "type": "Microsoft.Automation/automationAccounts",
             "apiVersion": "2018-06-30",
             "name": "[parameters('automationAccountName')]",
-            "location": "[parameters('location')]",
+            "location": "eastus2",
             "dependsOn": [
                 "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
             ],

--- a/deployments/azure_policy/azure_policy.parameters.sample.json
+++ b/deployments/azure_policy/azure_policy.parameters.sample.json
@@ -5,6 +5,7 @@
         "listOfAllowedLocations": {
             "value": [
                 "eastus",
+                "eastus2",
                 "westus"
             ]
         },


### PR DESCRIPTION
Fixes #8

- Updated Azure Policy Deployment to include East US 2 as an allowed location for the Azure Automation Account
- Updated the Azure Automation Account location to East US 2 in the Log Analytics Deployment

This should resolve the mapping issue.