### PR TITLE
Updated imageReference SKU for Windows 10 Client VM

### DIFF
--- a/deployments/azure_virtual_machine_windows_10_client/azure_virtual_machine_windows_10_client.json
+++ b/deployments/azure_virtual_machine_windows_10_client/azure_virtual_machine_windows_10_client.json
@@ -147,7 +147,7 @@
                     "imageReference": {
                         "publisher": "MicrosoftWindowsDesktop",
                         "offer": "Windows-10",
-                        "sku": "rs5-pro",
+                        "sku": "21h1-pro",
                         "version": "latest"
                     },
                     "osDisk": {


### PR DESCRIPTION
Updated to `21h1-pro` as the previous image is no longer available.